### PR TITLE
Add basic salon pages with React Query

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,7 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Environment Variables
+
+Create a `.env.local` file and define `NEXT_PUBLIC_API_URL` pointing to the backend API base URL.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "randevya-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.80.5",
         "next": "15.3.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -1261,6 +1262,32 @@
         "@tailwindcss/oxide": "4.1.8",
         "postcss": "^8.4.41",
         "tailwindcss": "4.1.8"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.80.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.80.5.tgz",
+      "integrity": "sha512-kFWXdQOUcjL/Ugk3GrI9eMuG3DsKBGaLIgyOLekR2UOrRrJgkLgPUNzZ10i8FCkfi4SgLABhOtQhx1HjoB9EZQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.80.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.80.5.tgz",
+      "integrity": "sha512-C0d+pvIahk6fJK5bXxyf36r9Ft6R9O0mwl781CjBrYGRJc76XRJcKhkVpxIo68cjMy3i47gd4O1EGooAke/OCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.80.5"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/package.json
+++ b/package.json
@@ -9,19 +9,20 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.80.5",
+    "next": "15.3.3",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "next": "15.3.3"
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@eslint/eslintrc": "^3",
+    "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.3.3",
-    "@eslint/eslintrc": "^3"
+    "tailwindcss": "^4",
+    "typescript": "^5"
   }
 }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,15 @@
+{
+  "name": "Randevya",
+  "short_name": "Randevya",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#000000",
+  "icons": [
+    {
+      "src": "/favicon.ico",
+      "sizes": "64x64 32x32 24x24 16x16",
+      "type": "image/x-icon"
+    }
+  ]
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import Providers from "@/lib/Providers";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -24,10 +25,13 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
+      <head>
+        <link rel="manifest" href="/manifest.json" />
+      </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <Providers>{children}</Providers>
       </body>
     </html>
   );

--- a/src/app/salons/[id]/page.tsx
+++ b/src/app/salons/[id]/page.tsx
@@ -1,0 +1,25 @@
+'use client'
+import { useQuery } from '@tanstack/react-query'
+import { useParams } from 'next/navigation'
+import { getSalon } from '@/lib/api'
+
+export default function SalonDetails() {
+  const params = useParams<{ id: string }>()
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['salon', params.id],
+    queryFn: () => getSalon(params.id),
+    enabled: !!params.id,
+  })
+
+  if (isLoading) return <p className="p-4">Loading...</p>
+  if (error || !data) return <p className="p-4 text-red-600">Failed to load</p>
+
+  return (
+    <div className="p-4 grid gap-2">
+      <h1 className="text-xl font-bold mb-2">{data.name}</h1>
+      <p>{data.location?.address}</p>
+      <p>{data.phone}</p>
+      <p>{data.email}</p>
+    </div>
+  )
+}

--- a/src/app/salons/page.tsx
+++ b/src/app/salons/page.tsx
@@ -1,0 +1,29 @@
+'use client'
+import { useQuery } from '@tanstack/react-query'
+import Link from 'next/link'
+import { getSalons } from '@/lib/api'
+
+export default function SalonList() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['salons'],
+    queryFn: getSalons,
+  })
+
+  if (isLoading) return <p className="p-4">Loading...</p>
+  if (error) return <p className="p-4 text-red-600">Error loading salons</p>
+
+  return (
+    <div className="p-4 grid gap-4">
+      {data?.map((salon) => (
+        <Link
+          key={salon.id}
+          href={`/salons/${salon.id}`}
+          className="p-4 rounded border bg-gray-50 hover:bg-gray-100"
+        >
+          <h2 className="font-semibold">{salon.name}</h2>
+          <p className="text-sm text-gray-600">{salon.location?.address}</p>
+        </Link>
+      ))}
+    </div>
+  )
+}

--- a/src/lib/Providers.tsx
+++ b/src/lib/Providers.tsx
@@ -1,0 +1,15 @@
+'use client'
+import { QueryClientProvider, HydrationBoundary } from '@tanstack/react-query'
+import { ReactNode, useState } from 'react'
+import { createQueryClient } from './queryClient'
+
+export default function Providers({ children }: { children: ReactNode }) {
+  const [client] = useState(() => createQueryClient())
+  return (
+    <QueryClientProvider client={client}>
+      <HydrationBoundary>
+        {children}
+      </HydrationBoundary>
+    </QueryClientProvider>
+  )
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,25 @@
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || ''
+
+export async function api<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`${API_BASE}${path}`, {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(init?.headers || {}),
+    },
+  })
+  if (!res.ok) {
+    throw new Error('Request failed')
+  }
+  return res.json()
+}
+
+import type { Salon } from '@/types/salon'
+
+export async function getSalons(): Promise<Salon[]> {
+  return api<Salon[]>('/salons')
+}
+
+export async function getSalon(id: string): Promise<Salon> {
+  return api<Salon>(`/salons/${id}`)
+}

--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -1,0 +1,11 @@
+import { QueryClient } from '@tanstack/react-query'
+
+export function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        refetchOnWindowFocus: false,
+      },
+    },
+  })
+}

--- a/src/types/salon.ts
+++ b/src/types/salon.ts
@@ -1,0 +1,13 @@
+export interface Location {
+  address: string
+  lat: number
+  lng: number
+}
+
+export interface Salon {
+  id: string
+  name: string
+  phone?: string
+  email?: string
+  location?: Location
+}


### PR DESCRIPTION
## Summary
- set up React Query provider
- add API helpers for salons
- add salons list and details pages
- include PWA manifest and link in layout
- document API base env variable

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts during build)*

------
https://chatgpt.com/codex/tasks/task_e_68417cb24a94832ba82754122d6f8fa0