### PR TITLE
Fix theme toggle and navigation

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -16,7 +16,7 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
 
   return (
     <div className="flex min-h-screen flex-col">
-      <Header />
+      <Header containerClassName="md:pl-64" />
       <div className="flex flex-1">
         {/* Mobile Sidebar */}
         <div

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -37,6 +37,23 @@
   }
 }
 
+/* Allow manual dark mode via `class="dark"` */
+.dark {
+  --background: #0f172a;
+  --foreground: #f8fafc;
+  --primary: #6366f1;
+  --primary-foreground: #ffffff;
+  --secondary: #1e293b;
+  --secondary-foreground: #cbd5e1;
+  --accent: #334155;
+  --accent-foreground: #f1f5f9;
+  --destructive: #ef4444;
+  --destructive-foreground: #ffffff;
+  --border: #334155;
+  --input: #1e293b;
+  --ring: #6366f1;
+}
+
 * {
   border-color: hsl(var(--border));
 }

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -7,7 +7,11 @@ import { Menu, X, User, LogOut } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { getAuthState, authStorage } from "@/lib/auth";
 
-export function Header() {
+interface HeaderProps {
+  containerClassName?: string;
+}
+
+export function Header({ containerClassName = "" }: HeaderProps) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [mounted, setMounted] = useState(false);
   const router = useRouter();
@@ -64,7 +68,7 @@ export function Header() {
 
   return (
     <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-      <div className="container mx-auto px-4">
+      <div className={`container mx-auto px-4 ${containerClassName}`}>
         <div className="flex h-16 items-center justify-between">
           {/* Logo */}
           <Link href="/" className="flex items-center space-x-2">
@@ -78,12 +82,14 @@ export function Header() {
 
           {/* Desktop Navigation */}
           <nav className="hidden md:flex items-center space-x-6">
-            <Link
-              href="/salons"
-              className="text-foreground/60 hover:text-foreground transition-colors"
-            >
-              Kuaför Bul
-            </Link>
+            {!isAuthenticated && (
+              <Link
+                href="/salons"
+                className="text-foreground/60 hover:text-foreground transition-colors"
+              >
+                Kuaför Bul
+              </Link>
+            )}
             {renderAuthContent()}
           </nav>
 
@@ -106,13 +112,15 @@ export function Header() {
         {isMenuOpen && (
           <div className="md:hidden border-t py-4">
             <nav className="flex flex-col space-y-4">
-              <Link
-                href="/salons"
-                className="text-foreground/60 hover:text-foreground transition-colors"
-                onClick={() => setIsMenuOpen(false)}
-              >
-                Kuaför Bul
-              </Link>
+              {!isAuthenticated && (
+                <Link
+                  href="/salons"
+                  className="text-foreground/60 hover:text-foreground transition-colors"
+                  onClick={() => setIsMenuOpen(false)}
+                >
+                  Kuaför Bul
+                </Link>
+              )}
               {mounted && isAuthenticated ? (
                 <>
                   <Link


### PR DESCRIPTION
## Summary
- support manual dark mode via `.dark` class
- offset header when sidebar is visible
- hide "Kuaför Bul" link for authenticated users

## Testing
- `npm run lint` *(fails: Failed to load config "next/core-web-vitals" to extend from; see logs)*
- `npm run build` *(fails: Failed to fetch font `Inter`; see logs)*

------
https://chatgpt.com/codex/tasks/task_e_684204495d74832b8ba67c5e06530965