### PR TITLE
Add staff pages and nav links

### DIFF
--- a/src/app/dashboard/appointments/page.tsx
+++ b/src/app/dashboard/appointments/page.tsx
@@ -1,0 +1,17 @@
+import { Metadata } from "next";
+import { DashboardHeader } from "@/components/dashboard/header";
+import { DashboardShell } from "@/components/dashboard/shell";
+
+export const metadata: Metadata = {
+  title: "Randevular",
+  description: "Randevu yönetimi",
+};
+
+export default function AppointmentsPage() {
+  return (
+    <DashboardShell>
+      <DashboardHeader heading="Randevular" text="Randevu yönetimi" />
+      <p>Bu bölüm yakında eklenecek.</p>
+    </DashboardShell>
+  );
+}

--- a/src/app/dashboard/customers/page.tsx
+++ b/src/app/dashboard/customers/page.tsx
@@ -1,0 +1,17 @@
+import { Metadata } from "next";
+import { DashboardHeader } from "@/components/dashboard/header";
+import { DashboardShell } from "@/components/dashboard/shell";
+
+export const metadata: Metadata = {
+  title: "Müşteriler",
+  description: "Müşteri yönetimi",
+};
+
+export default function CustomersPage() {
+  return (
+    <DashboardShell>
+      <DashboardHeader heading="Müşteriler" text="Müşteri yönetimi" />
+      <p>Bu bölüm yakında eklenecek.</p>
+    </DashboardShell>
+  );
+}

--- a/src/app/dashboard/services/page.tsx
+++ b/src/app/dashboard/services/page.tsx
@@ -1,0 +1,17 @@
+import { Metadata } from "next";
+import { DashboardHeader } from "@/components/dashboard/header";
+import { DashboardShell } from "@/components/dashboard/shell";
+
+export const metadata: Metadata = {
+  title: "Hizmetler",
+  description: "Hizmet yönetimi",
+};
+
+export default function ServicesPage() {
+  return (
+    <DashboardShell>
+      <DashboardHeader heading="Hizmetler" text="Hizmet yönetimi" />
+      <p>Bu bölüm yakında eklenecek.</p>
+    </DashboardShell>
+  );
+}

--- a/src/app/dashboard/staff/[id]/analytics/page.tsx
+++ b/src/app/dashboard/staff/[id]/analytics/page.tsx
@@ -1,0 +1,22 @@
+import { Metadata } from "next";
+import { DashboardHeader } from "@/components/dashboard/header";
+import { DashboardShell } from "@/components/dashboard/shell";
+import { StaffAnalytics } from "@/components/staff/staff-analytics";
+
+export const metadata: Metadata = {
+  title: "Personel Analizi",
+  description: "Çalışan performans analizi",
+};
+
+interface StaffAnalyticsPageProps {
+  params: { id: string };
+}
+
+export default function StaffAnalyticsPage({ params }: StaffAnalyticsPageProps) {
+  return (
+    <DashboardShell>
+      <DashboardHeader heading="Analiz" text="Personel performans analizi" />
+      <StaffAnalytics staffId={params.id} />
+    </DashboardShell>
+  );
+}

--- a/src/app/dashboard/staff/[id]/calendar/page.tsx
+++ b/src/app/dashboard/staff/[id]/calendar/page.tsx
@@ -1,0 +1,22 @@
+import { Metadata } from "next";
+import { DashboardHeader } from "@/components/dashboard/header";
+import { DashboardShell } from "@/components/dashboard/shell";
+import { StaffCalendar } from "@/components/staff/staff-calendar";
+
+export const metadata: Metadata = {
+  title: "Personel Takvimi",
+  description: "Çalışan randevu takvimi",
+};
+
+interface StaffCalendarPageProps {
+  params: { id: string };
+}
+
+export default function StaffCalendarPage({ params }: StaffCalendarPageProps) {
+  return (
+    <DashboardShell>
+      <DashboardHeader heading="Takvim" text="Personel randevu takvimi" />
+      <StaffCalendar staffId={params.id} />
+    </DashboardShell>
+  );
+}

--- a/src/app/dashboard/staff/page.tsx
+++ b/src/app/dashboard/staff/page.tsx
@@ -1,0 +1,18 @@
+import { Metadata } from "next";
+import { DashboardHeader } from "@/components/dashboard/header";
+import { DashboardShell } from "@/components/dashboard/shell";
+import { StaffList } from "@/components/staff/staff-list";
+
+export const metadata: Metadata = {
+  title: "Personel",
+  description: "Çalışanlarınızı yönetin",
+};
+
+export default function StaffPage() {
+  return (
+    <DashboardShell>
+      <DashboardHeader heading="Personel" text="Çalışanlarınızı yönetin." />
+      <StaffList />
+    </DashboardShell>
+  );
+}

--- a/src/components/dashboard/nav.tsx
+++ b/src/components/dashboard/nav.tsx
@@ -7,6 +7,7 @@ import {
   Calendar,
   Settings,
   Users,
+  User,
   LayoutDashboard,
   Scissors,
 } from "lucide-react";
@@ -21,6 +22,11 @@ const items = [
     title: "Randevular",
     href: "/dashboard/appointments",
     icon: Calendar,
+  },
+  {
+    title: "Personel",
+    href: "/dashboard/staff",
+    icon: User,
   },
   {
     title: "Müşteriler",

--- a/src/components/layout/adaptive-nav.tsx
+++ b/src/components/layout/adaptive-nav.tsx
@@ -31,6 +31,11 @@ const navItems = [
     icon: Calendar,
   },
   {
+    title: "Personel",
+    href: "/dashboard/staff",
+    icon: User,
+  },
+  {
     title: "Müşteriler",
     href: "/dashboard/customers",
     icon: Users,

--- a/src/components/layout/auth-nav.tsx
+++ b/src/components/layout/auth-nav.tsx
@@ -5,6 +5,7 @@ import {
   Calendar,
   Settings,
   Users,
+  User,
   LayoutDashboard,
   Scissors,
 } from "lucide-react";
@@ -20,6 +21,11 @@ const navItems = [
     title: "Randevular",
     href: "/dashboard/appointments",
     icon: Calendar,
+  },
+  {
+    title: "Personel",
+    href: "/dashboard/staff",
+    icon: User,
   },
   {
     title: "Müşteriler",

--- a/src/components/staff/staff-analytics.tsx
+++ b/src/components/staff/staff-analytics.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { useStaffMetrics } from "@/hooks/staff";
+
+interface StaffAnalyticsProps {
+  staffId: string;
+}
+
+export function StaffAnalytics({ staffId }: StaffAnalyticsProps) {
+  const { data, isLoading } = useStaffMetrics(staffId);
+
+  if (isLoading) {
+    return <p>Yükleniyor...</p>;
+  }
+
+  return (
+    <pre className="whitespace-pre-wrap">{JSON.stringify(data, null, 2)}</pre>
+  );
+}

--- a/src/components/staff/staff-calendar.tsx
+++ b/src/components/staff/staff-calendar.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useStaffCalendar } from "@/hooks/staff";
+
+interface StaffCalendarProps {
+  staffId: string;
+}
+
+export function StaffCalendar({ staffId }: StaffCalendarProps) {
+  const today = new Date().toISOString().split("T")[0];
+  const { data, isLoading } = useStaffCalendar(staffId, "day", today);
+
+  if (isLoading) {
+    return <p>Yükleniyor...</p>;
+  }
+
+  return (
+    <ul className="space-y-1">
+      {data?.map((appt) => (
+        <li key={appt.id} className="border rounded p-2">
+          {appt.date} {appt.time} - {appt.customerName}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/staff/staff-list.tsx
+++ b/src/components/staff/staff-list.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { staffApi } from "@/lib/api";
+import { Card } from "@/components/ui/card";
+
+export function StaffList() {
+  const { data, isLoading } = useQuery({
+    queryKey: ["staff"],
+    queryFn: () => staffApi.getAll(),
+  });
+
+  if (isLoading) {
+    return <p>Yükleniyor...</p>;
+  }
+
+  return (
+    <div className="space-y-2">
+      {data?.map((staff) => (
+        <Card key={staff.id} className="p-4">
+          {staff.name}
+        </Card>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add staff listing and analytics components
- create dashboard subpages for staff, appointments, services and customers
- hook up calendar and analytics pages for each staff member
- expose staff routes in dashboard navigation

## Testing
- `npm run lint` *(fails: next not found due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684454cb7120832ba582013ce8d780d9