### PR TITLE
Add basic staff management components

### DIFF
--- a/src/components/staff/StaffAnalytics.tsx
+++ b/src/components/staff/StaffAnalytics.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useStaffMetrics } from "@/hooks/staff";
+import { LoadingSpinner } from "@/components/ui/loading";
+
+interface StaffAnalyticsProps {
+  staffId: string;
+}
+
+export function StaffAnalytics({ staffId }: StaffAnalyticsProps) {
+  const { data, isLoading, isError } = useStaffMetrics(staffId);
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center p-4">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  if (isError || !data) {
+    return <p className="p-4 text-sm text-red-500">Veriler yüklenemedi.</p>;
+  }
+
+  return (
+    <div className="space-y-2 text-sm">
+      <p>Toplam Randevu: {data.appointmentCount}</p>
+      <p>Toplam Gelir: ₺{data.revenue}</p>
+      {data.mostBookedService && (
+        <p>
+          En Popüler Hizmet: {data.mostBookedService.name} ({
+            data.mostBookedService.count
+          })
+        </p>
+      )}
+      <p>Kullanım Oranı: %{data.utilizationRate}</p>
+    </div>
+  );
+}

--- a/src/components/staff/StaffCalendar.tsx
+++ b/src/components/staff/StaffCalendar.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useStaffCalendar } from "@/hooks/staff";
+import { LoadingSpinner } from "@/components/ui/loading";
+
+interface StaffCalendarProps {
+  staffId: string;
+  range: string;
+  date: string;
+}
+
+export function StaffCalendar({ staffId, range, date }: StaffCalendarProps) {
+  const { data, isLoading, isError } = useStaffCalendar(staffId, range, date);
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center p-4">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  if (isError || !data) {
+    return <p className="p-4 text-sm text-red-500">Takvim verisi yüklenemedi.</p>;
+  }
+
+  if (data.length === 0) {
+    return <p className="p-4 text-sm text-muted-foreground">Randevu bulunmuyor.</p>;
+  }
+
+  return (
+    <ul className="space-y-2">
+      {data.map((appt) => (
+        <li key={appt.id} className="rounded border p-2">
+          <span className="font-medium">{appt.date}</span> {appt.time} - {appt.customerName}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/staff/StaffCard.tsx
+++ b/src/components/staff/StaffCard.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import type { Staff } from "@/types";
+
+interface StaffCardProps {
+  staff: Staff;
+}
+
+export function StaffCard({ staff }: StaffCardProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{staff.name}</CardTitle>
+      </CardHeader>
+      <CardContent className="text-sm text-muted-foreground">
+        Çalışan ID: {staff.id}
+      </CardContent>
+      <CardFooter className="space-x-2">
+        <Link href={`/dashboard/staff/${staff.id}/calendar`} passHref>
+          <Button size="sm" variant="secondary" asChild>
+            <span>Takvim</span>
+          </Button>
+        </Link>
+        <Link href={`/dashboard/staff/${staff.id}/analytics`} passHref>
+          <Button size="sm" variant="secondary" asChild>
+            <span>Analiz</span>
+          </Button>
+        </Link>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/src/components/staff/StaffList.tsx
+++ b/src/components/staff/StaffList.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { staffApi } from "@/lib/api";
+import type { Staff } from "@/types";
+import { LoadingSpinner } from "@/components/ui/loading";
+import { StaffCard } from "./StaffCard";
+
+interface StaffListProps {
+  salonId: string;
+}
+
+export function StaffList({ salonId }: StaffListProps) {
+  const { data, isLoading, isError } = useQuery<Staff[]>({
+    queryKey: ["salon", salonId, "staff"],
+    queryFn: () => staffApi.getBySalon(salonId),
+    enabled: !!salonId,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center p-4">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  if (isError || !data) {
+    return <p className="p-4 text-sm text-red-500">Çalışanlar yüklenemedi.</p>;
+  }
+
+  if (data.length === 0) {
+    return <p className="p-4 text-sm text-muted-foreground">Henüz çalışan yok.</p>;
+  }
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+      {data.map((staff) => (
+        <StaffCard key={staff.id} staff={staff} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/staff/index.ts
+++ b/src/components/staff/index.ts
@@ -1,0 +1,4 @@
+export * from "./StaffList";
+export * from "./StaffCard";
+export * from "./StaffCalendar";
+export * from "./StaffAnalytics";


### PR DESCRIPTION
## Summary
- add `StaffList` to list staff for a salon
- create `StaffCard` with links to calendar and analytics
- implement `StaffCalendar` using `useStaffCalendar`
- show metrics in `StaffAnalytics`
- export new components from `components/staff/index.ts`

## Testing
- `npx tsc --noEmit`
- `npm run lint` *(fails: project has existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684454cbca64832b9301197cda794c81