### PR TITLE
Add staff analytics and calendar components

### DIFF
--- a/src/components/staff/staff-analytics.tsx
+++ b/src/components/staff/staff-analytics.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useStaffMetrics } from "@/hooks/staff";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { LoadingSpinner } from "@/components/ui/loading";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+
+interface StaffAnalyticsProps {
+  staffId: string;
+}
+
+export function StaffAnalytics({ staffId }: StaffAnalyticsProps) {
+  const { data, isLoading, isError } = useStaffMetrics(staffId);
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center p-4">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <div className="p-4 text-center text-sm text-red-500">
+        Analitik veriler alınırken bir hata oluştu.
+      </div>
+    );
+  }
+
+  const chartData = [
+    { name: "Randevular", value: data.appointmentCount },
+    { name: "Gelir", value: data.revenue },
+    { name: "En Popüler", value: data.mostBookedService?.count ?? 0 },
+    { name: "Doluluk", value: data.utilizationRate },
+  ];
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Analitik</CardTitle>
+      </CardHeader>
+      <CardContent className="h-72">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={chartData} margin={{ top: 20, right: 20, left: 0, bottom: 0 }}>
+            <XAxis dataKey="name" />
+            <YAxis />
+            <Tooltip />
+            <Bar dataKey="value" fill="#8884d8" />
+          </BarChart>
+        </ResponsiveContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/staff/staff-calendar.tsx
+++ b/src/components/staff/staff-calendar.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useStaffCalendar } from "@/hooks/staff";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { LoadingSpinner } from "@/components/ui/loading";
+
+interface StaffCalendarProps {
+  staffId: string;
+  range: string;
+  date: string;
+}
+
+export function StaffCalendar({ staffId, range, date }: StaffCalendarProps) {
+  const { data, isLoading, isError } = useStaffCalendar(staffId, range, date);
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center p-4">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="p-4 text-center text-sm text-red-500">
+        Takvim verileri alınırken bir hata oluştu.
+      </div>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Takvim</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ul className="space-y-2">
+          {data?.map((appointment) => (
+            <li key={appointment.id} className="text-sm">
+              <span className="font-medium">{appointment.date}</span>{" "}
+              {appointment.time} - {appointment.customerName}
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- add `StaffCalendar` component that displays appointments
- add `StaffAnalytics` component that charts staff metrics

## Testing
- `npm run lint` *(fails: various lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684454cbd494832ba8e098df31c87282