### PR TITLE
Add reusable calendar component

### DIFF
--- a/src/components/calendar/calendar.tsx
+++ b/src/components/calendar/calendar.tsx
@@ -1,0 +1,104 @@
+import React, { useState } from "react";
+import {
+  addDays,
+  addMonths,
+  addWeeks,
+  endOfMonth,
+  endOfWeek,
+  format,
+  isSameDay,
+  parseISO,
+  startOfMonth,
+  startOfWeek,
+  subMonths,
+  subWeeks,
+} from "date-fns";
+import { cn } from "@/lib/utils";
+
+export interface CalendarEvent {
+  id: string;
+  date: string; // ISO date string (yyyy-MM-dd)
+  time?: string;
+  title: string;
+}
+
+export interface CalendarProps {
+  events: CalendarEvent[];
+  view?: "week" | "month";
+  date?: Date;
+  onDateChange?: (date: Date) => void;
+  renderEvent?: (event: CalendarEvent) => React.ReactNode;
+  className?: string;
+}
+
+export function Calendar({
+  events,
+  view = "month",
+  date: initialDate = new Date(),
+  onDateChange,
+  renderEvent,
+  className,
+}: CalendarProps) {
+  const [currentDate, setCurrentDate] = useState(initialDate);
+
+  const start =
+    view === "month"
+      ? startOfWeek(startOfMonth(currentDate))
+      : startOfWeek(currentDate);
+  const end =
+    view === "month"
+      ? endOfWeek(endOfMonth(currentDate))
+      : endOfWeek(currentDate);
+
+  const days: Date[] = [];
+  for (let day = start; day <= end; day = addDays(day, 1)) {
+    days.push(day);
+  }
+
+  const handlePrev = () => {
+    const newDate = view === "month" ? subMonths(currentDate, 1) : subWeeks(currentDate, 1);
+    setCurrentDate(newDate);
+    onDateChange?.(newDate);
+  };
+
+  const handleNext = () => {
+    const newDate = view === "month" ? addMonths(currentDate, 1) : addWeeks(currentDate, 1);
+    setCurrentDate(newDate);
+    onDateChange?.(newDate);
+  };
+
+  return (
+    <div className={cn("space-y-2", className)}>
+      <div className="flex items-center justify-between">
+        <button onClick={handlePrev} className="px-2 text-sm font-medium">&lt;</button>
+        <div className="font-semibold">
+          {view === "month"
+            ? format(currentDate, "MMMM yyyy")
+            : `${format(start, "MMM d")} - ${format(end, "MMM d")}`}
+        </div>
+        <button onClick={handleNext} className="px-2 text-sm font-medium">&gt;</button>
+      </div>
+      <div className="grid grid-cols-7 gap-px border text-sm">
+        {['Sun','Mon','Tue','Wed','Thu','Fri','Sat'].map(d => (
+          <div key={d} className="bg-muted p-1 text-center font-medium">
+            {d}
+          </div>
+        ))}
+        {days.map(day => (
+          <div key={day.toISOString()} className="h-24 border p-1 align-top">
+            <div className="text-xs font-medium">{format(day, 'd')}</div>
+            {events
+              .filter(e => isSameDay(parseISO(e.date), day))
+              .map(e => (
+                <div key={e.id} className="mt-1 truncate text-xs">
+                  {renderEvent ? renderEvent(e) : (
+                    <span>{e.time ? `${e.time} - ` : ''}{e.title}</span>
+                  )}
+                </div>
+              ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/calendar/index.ts
+++ b/src/components/calendar/index.ts
@@ -1,0 +1,2 @@
+export * from "./calendar";
+export * from "./staff-calendar";

--- a/src/components/calendar/staff-calendar.tsx
+++ b/src/components/calendar/staff-calendar.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import React, { useState } from "react";
+import { format } from "date-fns";
+import { useStaffCalendar } from "@/hooks/staff/use-staff-calendar";
+import { Calendar, CalendarEvent } from "./calendar";
+
+interface StaffCalendarProps {
+  staffId: string;
+  view?: "week" | "month";
+}
+
+export function StaffCalendar({ staffId, view = "week" }: StaffCalendarProps) {
+  const [date, setDate] = useState(new Date());
+  const { data } = useStaffCalendar(
+    staffId,
+    view,
+    format(date, "yyyy-MM-dd")
+  );
+
+  const events: CalendarEvent[] =
+    data?.map((a) => ({
+      id: a.id,
+      date: a.date,
+      time: a.time,
+      title: a.customerName,
+    })) ?? [];
+
+  return (
+    <Calendar
+      events={events}
+      view={view}
+      date={date}
+      onDateChange={setDate}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- create generic calendar handling week and month views
- map staff appointments into new calendar component

## Testing
- `npm install --legacy-peer-deps`
- *(fails: lint unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_684454cc89e4832b974688b06162cc52