### PR TITLE
Implement dashboard metrics hook

### DIFF
--- a/src/components/dashboard/overview.tsx
+++ b/src/components/dashboard/overview.tsx
@@ -1,7 +1,12 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Calendar, Users, Clock, DollarSign } from "lucide-react";
+import { LoadingSpinner } from "@/components/ui/loading";
+import { useDashboardMetrics } from "@/hooks/use-dashboard-metrics";
+import { formatCurrency, formatDuration } from "@/lib/utils";
 
 export function Overview() {
+  const { data, isLoading } = useDashboardMetrics();
+
   return (
     <>
       <Card>
@@ -12,9 +17,13 @@ export function Overview() {
           <Calendar className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold">0</div>
+          <div className="text-2xl font-bold">
+            {isLoading ? <LoadingSpinner size="sm" /> : data.todayAppointments}
+          </div>
           <p className="text-xs text-muted-foreground">
-            Henüz randevu bulunmuyor
+            {data.todayAppointments === 0 && !isLoading
+              ? "Henüz randevu bulunmuyor"
+              : ""}
           </p>
         </CardContent>
       </Card>
@@ -24,9 +33,13 @@ export function Overview() {
           <Users className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold">0</div>
+          <div className="text-2xl font-bold">
+            {isLoading ? <LoadingSpinner size="sm" /> : data.totalCustomers}
+          </div>
           <p className="text-xs text-muted-foreground">
-            Henüz müşteri bulunmuyor
+            {data.totalCustomers === 0 && !isLoading
+              ? "Henüz müşteri bulunmuyor"
+              : ""}
           </p>
         </CardContent>
       </Card>
@@ -36,8 +49,18 @@ export function Overview() {
           <Clock className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold">0 dk</div>
-          <p className="text-xs text-muted-foreground">Henüz veri bulunmuyor</p>
+          <div className="text-2xl font-bold">
+            {isLoading ? (
+              <LoadingSpinner size="sm" />
+            ) : data.averageDuration > 0 ? (
+              formatDuration(data.averageDuration)
+            ) : (
+              "0 dk"
+            )}
+          </div>
+          <p className="text-xs text-muted-foreground">
+            {data.averageDuration === 0 && !isLoading ? "Henüz veri bulunmuyor" : ""}
+          </p>
         </CardContent>
       </Card>
       <Card>
@@ -46,9 +69,17 @@ export function Overview() {
           <DollarSign className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold">₺0</div>
+          <div className="text-2xl font-bold">
+            {isLoading ? (
+              <LoadingSpinner size="sm" />
+            ) : data.monthlyRevenue > 0 ? (
+              formatCurrency(data.monthlyRevenue)
+            ) : (
+              "₺0"
+            )}
+          </div>
           <p className="text-xs text-muted-foreground">
-            Henüz gelir bulunmuyor
+            {data.monthlyRevenue === 0 && !isLoading ? "Henüz gelir bulunmuyor" : ""}
           </p>
         </CardContent>
       </Card>

--- a/src/hooks/use-dashboard-metrics.ts
+++ b/src/hooks/use-dashboard-metrics.ts
@@ -1,0 +1,74 @@
+import { useQuery } from "@tanstack/react-query";
+import { appointmentsApi, salonsApi } from "@/lib/api";
+import type { Appointment, Salon } from "@/types";
+
+interface DashboardMetrics {
+  todayAppointments: number;
+  totalCustomers: number;
+  averageDuration: number;
+  monthlyRevenue: number;
+  salon?: Salon;
+}
+
+export function useDashboardMetrics() {
+  const appointmentsQuery = useQuery<Appointment[]>({
+    queryKey: ["dashboard", "appointments"],
+    queryFn: appointmentsApi.getAll,
+  });
+
+  const salonQuery = useQuery<Salon>({
+    queryKey: ["dashboard", "salon"],
+    queryFn: salonsApi.getMe,
+  });
+
+  const appointments = appointmentsQuery.data ?? [];
+  const today = new Date().toISOString().split("T")[0];
+
+  const todayAppointments = appointments.filter((a) => a.date === today).length;
+
+  const totalCustomers = new Set(
+    appointments.map((a) => a.customerPhone || a.customerEmail || a.customerName)
+  ).size;
+
+  let averageDuration = 0;
+  let monthlyRevenue = 0;
+
+  if (appointments.length) {
+    const now = new Date();
+    let totalDuration = 0;
+    let durationCount = 0;
+
+    appointments.forEach((a) => {
+      const appointmentDate = new Date(a.date);
+      const service: any = (a as any).service;
+      if (service?.durationMinutes) {
+        totalDuration += service.durationMinutes;
+        durationCount += 1;
+      }
+      if (
+        service?.price &&
+        appointmentDate.getMonth() === now.getMonth() &&
+        appointmentDate.getFullYear() === now.getFullYear()
+      ) {
+        monthlyRevenue += service.price;
+      }
+    });
+
+    if (durationCount) {
+      averageDuration = Math.round(totalDuration / durationCount);
+    }
+  }
+
+  const metrics: DashboardMetrics = {
+    todayAppointments,
+    totalCustomers,
+    averageDuration,
+    monthlyRevenue,
+    salon: salonQuery.data,
+  };
+
+  return {
+    data: metrics,
+    isLoading: appointmentsQuery.isLoading || salonQuery.isLoading,
+  };
+}


### PR DESCRIPTION
## Summary
- add `useDashboardMetrics` hook to fetch salon stats
- replace overview placeholders with metrics

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684454ce46a0832b8c77ebe664764179