### PR TITLE
Remove duplicate Personel navigation entry

### DIFF
--- a/src/components/owner/dashboard/nav.tsx
+++ b/src/components/owner/dashboard/nav.tsx
@@ -44,11 +44,6 @@ const ownerItems = [
     href: "/dashboard/settings",
     icon: Settings,
   },
-  {
-    title: "Personel",
-    href: "/dashboard/staff",
-    icon: Users,
-  },
 ];
 
 const staffItems = [


### PR DESCRIPTION
## Summary
- clean up `ownerItems` navigation list in dashboard nav

## Testing
- `npm install --legacy-peer-deps`
- `npm run lint` *(fails: ESLint not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684460cbfe54832ba4ba7a665464bdbd