### PR TITLE
Add all appointments hook and owner-only calendar

### DIFF
--- a/src/app/dashboard/appointments/page.tsx
+++ b/src/app/dashboard/appointments/page.tsx
@@ -1,21 +1,73 @@
 import { Metadata } from "next";
+import { redirect } from "next/navigation";
 import { DashboardHeader } from "@/components/owner/dashboard/header";
 import { DashboardShell } from "@/components/owner/dashboard/shell";
-import { Calendar } from "@/components/calendar/calendar";
+import { Calendar, type CalendarEvent } from "@/components/calendar/calendar";
+import { LoadingSpinner } from "@/components/ui/loading";
+import { useAllStaffAppointments } from "@/hooks/use-all-staff-appointments";
+import { getServerAuthState } from "@/lib/server-auth";
 
 export const metadata: Metadata = {
   title: "Randevular",
   description: "Randevu yönetimi",
 };
 
-export default function AppointmentsPage() {
+function AppointmentsCalendar() {
+  "use client";
+
+  const { data, isLoading, isError } = useAllStaffAppointments();
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center p-4">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <p className="p-4 text-center text-sm text-red-500">
+        Randevular yüklenemedi.
+      </p>
+    );
+  }
+
+  if (!data || data.length === 0) {
+    return (
+      <p className="p-4 text-center text-sm text-muted-foreground">
+        Henüz randevu yok.
+      </p>
+    );
+  }
+
+  const events: CalendarEvent[] = data.map((a) => ({
+    id: a.id,
+    date: a.date,
+    time: a.time,
+    title: a.customerName,
+  }));
+
+  return <Calendar events={events} />;
+}
+
+export default async function AppointmentsPage() {
+  const { role, user } = await getServerAuthState();
+
+  if (role !== "owner") {
+    if (user?.id) {
+      redirect(`/dashboard/staff/${user.id}/calendar`);
+    }
+    redirect("/dashboard");
+  }
+
   return (
     <DashboardShell>
       {/* <DashboardHeader
         heading="Randevular"
         text="Randevu yönetimi"
       /> */}
-      <Calendar events={[]} />
+      <AppointmentsCalendar />
     </DashboardShell>
   );
 }

--- a/src/hooks/use-all-staff-appointments.ts
+++ b/src/hooks/use-all-staff-appointments.ts
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/react-query";
+import { appointmentsApi } from "@/lib/api";
+import type { Appointment } from "@/types";
+
+export function useAllStaffAppointments() {
+  return useQuery<Appointment[]>({
+    queryKey: ["appointments", "all"],
+    queryFn: appointmentsApi.getAll,
+  });
+}


### PR DESCRIPTION
## Summary
- add `useAllStaffAppointments` hook for fetching appointments
- display appointments as calendar events on the dashboard
- restrict `/dashboard/appointments` to owners and redirect others

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684460cab6b8832baf335ebeddc66db8