### PR TITLE
Add basic salons pages

### DIFF
--- a/src/app/salons/[id]/page.tsx
+++ b/src/app/salons/[id]/page.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
+import { salonsApi, servicesApi } from "@/lib/api";
+import type { Salon, Service } from "@/types";
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { LoadingPage } from "@/components/ui/loading";
+
+export default function SalonDetailPage() {
+  const params = useParams();
+  const id = Array.isArray(params.id) ? params.id[0] : (params.id as string);
+
+  const salonQuery = useQuery<Salon>({
+    queryKey: ["salon", id],
+    queryFn: () => salonsApi.getById(id),
+    enabled: !!id,
+  });
+
+  const servicesQuery = useQuery<Service[]>({
+    queryKey: ["services", id],
+    queryFn: () => servicesApi.getBySalon(id),
+    enabled: !!id,
+  });
+
+  if (salonQuery.isLoading || servicesQuery.isLoading) {
+    return <LoadingPage />;
+  }
+
+  if (salonQuery.isError || !salonQuery.data) {
+    return <p className="p-4 text-sm text-red-500">Kuaför bulunamadı.</p>;
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8 space-y-6">
+      <div className="space-y-2">
+        <h1 className="text-2xl font-bold">{salonQuery.data.name}</h1>
+        <p className="text-sm text-muted-foreground">
+          {salonQuery.data.location.address}
+        </p>
+      </div>
+
+      <div className="space-y-4">
+        <h2 className="text-xl font-semibold">Hizmetler</h2>
+        {servicesQuery.isError && (
+          <p className="text-sm text-red-500">Hizmetler yüklenemedi.</p>
+        )}
+        {servicesQuery.data && servicesQuery.data.length === 0 && (
+          <p className="text-sm text-muted-foreground">Hizmet bulunamadı.</p>
+        )}
+        {servicesQuery.data && servicesQuery.data.length > 0 && (
+          <div className="space-y-2">
+            {servicesQuery.data.map((service) => (
+              <Card key={service.id} className="p-4 flex justify-between">
+                <span>{service.name}</span>
+                <span className="text-sm text-muted-foreground">
+                  {service.price}₺
+                </span>
+              </Card>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <Link href={`/book?salonId=${id}`}> 
+        <Button className="mt-4">Randevu Al</Button>
+      </Link>
+    </div>
+  );
+}

--- a/src/app/salons/page.tsx
+++ b/src/app/salons/page.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import Link from "next/link";
+import { useQuery } from "@tanstack/react-query";
+import { salonsApi } from "@/lib/api";
+import type { Salon } from "@/types";
+import { Card } from "@/components/ui/card";
+import { LoadingPage } from "@/components/ui/loading";
+
+export default function SalonsPage() {
+  const { data, isLoading, isError } = useQuery<Salon[]>({
+    queryKey: ["salons"],
+    queryFn: salonsApi.getAll,
+  });
+
+  if (isLoading) {
+    return <LoadingPage />;
+  }
+
+  if (isError || !data) {
+    return <p className="p-4 text-sm text-red-500">Kuaförler yüklenemedi.</p>;
+  }
+
+  if (data.length === 0) {
+    return <p className="p-4 text-sm text-muted-foreground">Kuaför bulunamadı.</p>;
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8 space-y-4">
+      <h1 className="text-2xl font-bold">Kuaförler</h1>
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {data.map((salon) => (
+          <Link key={salon.id} href={`/salons/${salon.id}`}>
+            <Card className="p-4 hover:shadow-md transition-shadow">
+              <p className="font-semibold">{salon.name}</p>
+              <p className="text-sm text-muted-foreground">
+                {salon.location.address}
+              </p>
+            </Card>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement `/salons` list with salonsApi
- implement `/salons/[id]` details page with services

## Testing
- `npm run lint` *(fails: Failed to load config "next/core-web-vitals" to extend from)*

------
https://chatgpt.com/codex/tasks/task_e_685ee9aeea20832b835f46fe80a5ac95