### PR TITLE
Add salon calendar analytics page

### DIFF
--- a/src/app/dashboard/calendar/calendar-client.tsx
+++ b/src/app/dashboard/calendar/calendar-client.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useState } from "react";
+import { SalonCalendar, SalonAnalytics } from "@/components/salon";
+import { Button } from "@/components/ui/button";
+
+export function CalendarClient() {
+  const [view, setView] = useState<"week" | "month">("month");
+
+  return (
+    <>
+      <div className="flex justify-end mb-4 space-x-2">
+        <Button
+          variant={view === "week" ? "default" : "outline"}
+          onClick={() => setView("week")}
+        >
+          Haftalık
+        </Button>
+        <Button
+          variant={view === "month" ? "default" : "outline"}
+          onClick={() => setView("month")}
+        >
+          Aylık
+        </Button>
+      </div>
+      <div className="grid gap-4 md:grid-cols-2">
+        <SalonCalendar view={view} />
+        <SalonAnalytics />
+      </div>
+    </>
+  );
+}

--- a/src/app/dashboard/calendar/page.tsx
+++ b/src/app/dashboard/calendar/page.tsx
@@ -1,0 +1,16 @@
+import { Metadata } from "next";
+import { DashboardShell } from "@/components/owner/dashboard/shell";
+import { CalendarClient } from "./calendar-client";
+
+export const metadata: Metadata = {
+  title: "Takvim",
+  description: "Salon takvimi ve analizleri",
+};
+
+export default function SalonCalendarPage() {
+  return (
+    <DashboardShell>
+      <CalendarClient />
+    </DashboardShell>
+  );
+}

--- a/src/components/salon/index.ts
+++ b/src/components/salon/index.ts
@@ -1,0 +1,2 @@
+export * from "./salon-calendar";
+export * from "./salon-analytics";

--- a/src/components/salon/salon-analytics.tsx
+++ b/src/components/salon/salon-analytics.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useSalonMetrics } from "@/hooks/salon";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { LoadingSpinner } from "@/components/ui/loading";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+
+interface SalonAnalyticsProps {
+  salonId?: string;
+}
+
+export function SalonAnalytics({ salonId }: SalonAnalyticsProps) {
+  const { data, isLoading, isError } = useSalonMetrics(salonId);
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center p-4">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <div className="p-4 text-center text-sm text-red-500">
+        Analitik veriler alınırken bir hata oluştu.
+      </div>
+    );
+  }
+
+  const chartData = [
+    { name: "Randevular", value: data.appointmentCount },
+    { name: "Gelir", value: data.revenue },
+    { name: "En Popüler", value: data.mostBookedService?.count ?? 0 },
+    { name: "Doluluk", value: data.utilizationRate },
+  ];
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Analitik</CardTitle>
+      </CardHeader>
+      <CardContent className="h-72">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={chartData} margin={{ top: 20, right: 20, left: 0, bottom: 0 }}>
+            <XAxis dataKey="name" />
+            <YAxis />
+            <Tooltip />
+            <Bar dataKey="value" fill="#8884d8" />
+          </BarChart>
+        </ResponsiveContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/salon/salon-calendar.tsx
+++ b/src/components/salon/salon-calendar.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import React, { useState } from "react";
+import { format } from "date-fns";
+import { Calendar, CalendarEvent } from "@/components/calendar/calendar";
+import { useSalonCalendar } from "@/hooks/salon";
+
+interface SalonCalendarProps {
+  salonId?: string;
+  view?: "week" | "month";
+}
+
+export function SalonCalendar({ salonId, view = "week" }: SalonCalendarProps) {
+  const [date, setDate] = useState(new Date());
+  const { data } = useSalonCalendar(view, format(date, "yyyy-MM-dd"), salonId);
+
+  const events: CalendarEvent[] =
+    data?.map((a) => ({
+      id: a.id,
+      date: a.date,
+      time: a.time,
+      title: a.customerName,
+    })) ?? [];
+
+  return (
+    <Calendar
+      events={events}
+      view={view}
+      date={date}
+      onDateChange={setDate}
+    />
+  );
+}

--- a/src/hooks/salon/index.ts
+++ b/src/hooks/salon/index.ts
@@ -1,0 +1,2 @@
+export * from "./use-salon-calendar";
+export * from "./use-salon-metrics";

--- a/src/hooks/salon/use-salon-calendar.ts
+++ b/src/hooks/salon/use-salon-calendar.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import { salonsApi } from "@/lib/api";
+import type { Appointment } from "@/types";
+import { getAuthState } from "@/lib/auth";
+
+export function useSalonCalendar(range: string, date: string, salonId?: string) {
+  const id = salonId ?? getAuthState().user?.salonId;
+
+  return useQuery<Appointment[]>({
+    queryKey: ["salon", id, "calendar", range, date],
+    queryFn: () => salonsApi.getCalendar(id!, range, date),
+    enabled: !!id && !!range && !!date,
+  });
+}

--- a/src/hooks/salon/use-salon-metrics.ts
+++ b/src/hooks/salon/use-salon-metrics.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import { salonsApi } from "@/lib/api";
+import type { SalonMetrics } from "@/types";
+import { getAuthState } from "@/lib/auth";
+
+export function useSalonMetrics(salonId?: string) {
+  const id = salonId ?? getAuthState().user?.salonId;
+
+  return useQuery<SalonMetrics>({
+    queryKey: ["salon", id, "metrics"],
+    queryFn: () => salonsApi.getMetrics(id!),
+    enabled: !!id,
+  });
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -12,6 +12,7 @@ import type {
   CreateStaffDto,
   UpdateStaffDto,
   StaffMetrics,
+  SalonMetrics,
   Appointment,
   CreateAppointmentDto,
   UpdateAppointmentDto,
@@ -116,6 +117,9 @@ export const salonsApi = {
     apiRequest<void>(`/salons/${id}`, {
       method: "DELETE",
     }),
+  getMetrics: (id: string) => apiRequest<SalonMetrics>(`/salons/${id}/metrics`),
+  getCalendar: (id: string, range: string, date: string) =>
+    apiRequest<Appointment[]>(`/salons/${id}/calendar?range=${range}&date=${date}`),
 };
 
 // Services API

--- a/src/types/js-cookie.d.ts
+++ b/src/types/js-cookie.d.ts
@@ -1,0 +1,1 @@
+declare module 'js-cookie';

--- a/src/types/salon.ts
+++ b/src/types/salon.ts
@@ -20,3 +20,14 @@ export interface Salon {
   createdAt: Date;
   updatedAt: Date;
 }
+
+export interface SalonMetrics {
+  appointmentCount: number;
+  revenue: number;
+  mostBookedService: {
+    serviceId: string;
+    name: string;
+    count: number;
+  } | null;
+  utilizationRate: number;
+}


### PR DESCRIPTION
## Summary
- implement `salonsApi.getCalendar` and `salonsApi.getMetrics`
- add `SalonMetrics` type
- create hooks for salon calendar and metrics
- add `SalonCalendar` and `SalonAnalytics` components
- implement `/dashboard/calendar` page with weekly/monthly toggle
- declare js-cookie types

## Testing
- `npx tsc --noEmit`
- `npm run build` *(fails: Failed to fetch font `Inter`, network blocked)*
- `npm run lint` *(fails: ESLint not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685ee9b4972c832bb4a50144e7f46f0e