### PR TITLE
Add system admin routes and middleware checks

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,0 +1,16 @@
+import { DashboardNav } from "@/components/layout/dashboard-nav";
+
+interface AdminLayoutProps {
+  children: React.ReactNode;
+}
+
+export default function AdminLayout({ children }: AdminLayoutProps) {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <DashboardNav />
+      <main className="flex-1">
+        <div className="p-4 md:p-8">{children}</div>
+      </main>
+    </div>
+  );
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,27 @@
+import { Metadata } from "next";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { DashboardShell } from "@/components/dashboard/shell";
+
+export const metadata: Metadata = {
+  title: "Yönetim Paneli",
+  description: "Sistem yöneticisi için panel",
+};
+
+export default function AdminPage() {
+  return (
+    <DashboardShell>
+      <div className="space-y-4">
+        <h1 className="text-2xl font-bold">Yönetim Paneli</h1>
+        <div className="space-x-2">
+          <Link href="/admin/users">
+            <Button variant="secondary">Kullanıcılar</Button>
+          </Link>
+          <Link href="/admin/salons">
+            <Button variant="secondary">Salonlar</Button>
+          </Link>
+        </div>
+      </div>
+    </DashboardShell>
+  );
+}

--- a/src/app/admin/salons/page.tsx
+++ b/src/app/admin/salons/page.tsx
@@ -1,0 +1,16 @@
+import { Metadata } from "next";
+import { DashboardShell } from "@/components/dashboard/shell";
+import { SalonList } from "@/components/admin/SalonList";
+
+export const metadata: Metadata = {
+  title: "Salonlar",
+  description: "Salon yönetimi",
+};
+
+export default function AdminSalonsPage() {
+  return (
+    <DashboardShell>
+      <SalonList />
+    </DashboardShell>
+  );
+}

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -1,0 +1,16 @@
+import { Metadata } from "next";
+import { DashboardShell } from "@/components/dashboard/shell";
+import { UserList } from "@/components/admin/UserList";
+
+export const metadata: Metadata = {
+  title: "Kullanıcılar",
+  description: "Kullanıcı yönetimi",
+};
+
+export default function AdminUsersPage() {
+  return (
+    <DashboardShell>
+      <UserList />
+    </DashboardShell>
+  );
+}

--- a/src/components/admin/SalonList.tsx
+++ b/src/components/admin/SalonList.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { adminApi } from "@/lib/api";
+import type { Salon } from "@/types";
+import { Button } from "@/components/ui/button";
+import { Card, CardHeader, CardTitle, CardContent, CardFooter } from "@/components/ui/card";
+import { LoadingSpinner } from "@/components/ui/loading";
+
+export function SalonList() {
+  const queryClient = useQueryClient();
+  const { data, isLoading, isError } = useQuery<Salon[]>({
+    queryKey: ["admin", "salons"],
+    queryFn: adminApi.getAllSalons,
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => adminApi.deleteSalon(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["admin", "salons"] });
+    },
+  });
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center p-4">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  if (isError || !data) {
+    return <p className="p-4 text-sm text-red-500">Salonlar yüklenemedi.</p>;
+  }
+
+  if (data.length === 0) {
+    return <p className="p-4 text-sm text-muted-foreground">Henüz salon yok.</p>;
+  }
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+      {data.map((salon) => (
+        <Card key={salon.id}>
+          <CardHeader>
+            <CardTitle>{salon.name}</CardTitle>
+          </CardHeader>
+          <CardContent className="text-sm text-muted-foreground">
+            Email: {salon.email}
+          </CardContent>
+          <CardFooter>
+            <Button
+              size="sm"
+              variant="destructive"
+              onClick={() => deleteMutation.mutate(salon.id)}
+              disabled={deleteMutation.isPending}
+            >
+              Sil
+            </Button>
+          </CardFooter>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/src/components/admin/UserList.tsx
+++ b/src/components/admin/UserList.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { adminApi } from "@/lib/api";
+import type { User } from "@/types";
+import { Button } from "@/components/ui/button";
+import { Card, CardHeader, CardTitle, CardContent, CardFooter } from "@/components/ui/card";
+import { LoadingSpinner } from "@/components/ui/loading";
+
+export function UserList() {
+  const queryClient = useQueryClient();
+  const { data, isLoading, isError } = useQuery<User[]>({
+    queryKey: ["admin", "users"],
+    queryFn: adminApi.getAllUsers,
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => adminApi.deleteUser(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["admin", "users"] });
+    },
+  });
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center p-4">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  if (isError || !data) {
+    return <p className="p-4 text-sm text-red-500">Kullanıcılar yüklenemedi.</p>;
+  }
+
+  if (data.length === 0) {
+    return <p className="p-4 text-sm text-muted-foreground">Henüz kullanıcı yok.</p>;
+  }
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+      {data.map((user) => (
+        <Card key={user.id}>
+          <CardHeader>
+            <CardTitle>{user.email}</CardTitle>
+          </CardHeader>
+          <CardContent className="text-sm text-muted-foreground">Rol: {user.role}</CardContent>
+          <CardFooter>
+            <Button
+              size="sm"
+              variant="destructive"
+              onClick={() => deleteMutation.mutate(user.id)}
+              disabled={deleteMutation.isPending}
+            >
+              Sil
+            </Button>
+          </CardFooter>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/src/components/layout/adaptive-nav.tsx
+++ b/src/components/layout/adaptive-nav.tsx
@@ -70,6 +70,19 @@ const staffNavItems = [
   },
 ];
 
+const adminNavItems = [
+  {
+    title: "Kullanıcılar",
+    href: "/admin/users",
+    icon: Users,
+  },
+  {
+    title: "Salonlar",
+    href: "/admin/salons",
+    icon: Scissors,
+  },
+];
+
 export function AdaptiveNav({
   isAuthenticated = true,
   role = null,
@@ -83,7 +96,12 @@ export function AdaptiveNav({
   const navRef = useRef<HTMLElement>(null);
   const path = usePathname();
   const router = useRouter();
-  const navItems = role === "owner" ? ownerNavItems : staffNavItems;
+  const navItems =
+    role === "owner"
+      ? ownerNavItems
+      : role === "system_admin"
+      ? adminNavItems
+      : staffNavItems;
 
   useEffect(() => {
     setMounted(true);

--- a/src/components/layout/root-nav.tsx
+++ b/src/components/layout/root-nav.tsx
@@ -6,11 +6,12 @@ import { NavWrapper } from "./nav-wrapper";
 export function RootNav() {
   const pathname = usePathname();
   const isDashboardRoute = pathname?.startsWith("/dashboard");
+  const isAdminRoute = pathname?.startsWith("/admin");
   const isLoginPage = pathname === "/login";
   const isRegisterPage = pathname === "/register";
 
   // Do not render the navbar on dashboard routes or the login page
-  if (isDashboardRoute || isLoginPage || isRegisterPage) {
+  if (isDashboardRoute || isAdminRoute || isLoginPage || isRegisterPage) {
     return null;
   }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
 // Routes that require authentication
-const protectedRoutes = ["/dashboard"];
+const protectedRoutes = ["/dashboard", "/admin"];
 // Routes that should not be accessible when authenticated
 const authRoutes = ["/login", "/register"];
 
@@ -38,6 +38,16 @@ export async function middleware(request: NextRequest) {
     }
   }
 
+  // Role based access for admin routes
+  if (pathname.startsWith("/admin")) {
+    if (!token) {
+      return NextResponse.redirect(new URL("/login", request.url));
+    }
+    if (role !== "system_admin") {
+      return NextResponse.redirect(new URL("/dashboard", request.url));
+    }
+  }
+
   // Prevent authenticated users from accessing auth pages
   if (token && (pathname === "/login" || pathname === "/register")) {
     return NextResponse.redirect(new URL("/dashboard", request.url));
@@ -48,5 +58,5 @@ export async function middleware(request: NextRequest) {
 
 // Match all routes that start with /dashboard, /login, or /register
 export const config = {
-  matcher: ["/", "/dashboard/:path*", "/login", "/register"],
+  matcher: ["/", "/dashboard/:path*", "/admin/:path*", "/login", "/register"],
 };


### PR DESCRIPTION
## Summary
- build admin UI components for salons and users
- create admin pages under `/admin`
- restrict admin paths in middleware
- hide navbar on admin pages
- show admin nav items when signed in as system admin

## Testing
- `npm run lint` *(fails: Failed to load config "next/core-web-vitals" to extend from)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ee9b57cc0832bbb036ffbe0aa46c6