### PR TITLE
Add salon breadcrumbs and navigation buttons

### DIFF
--- a/src/app/salons/[id]/page.tsx
+++ b/src/app/salons/[id]/page.tsx
@@ -8,6 +8,7 @@ import type { Salon, Service } from "@/types";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { LoadingPage } from "@/components/ui/loading";
+import { Breadcrumbs } from "@/components/ui/breadcrumbs";
 
 export default function SalonDetailPage() {
   const params = useParams();
@@ -35,6 +36,21 @@ export default function SalonDetailPage() {
 
   return (
     <div className="container mx-auto px-4 py-8 space-y-6">
+      <Breadcrumbs
+        items={[
+          { label: "Ana Sayfa", href: "/" },
+          { label: "Kuaförler", href: "/salons" },
+          { label: salonQuery.data.name },
+        ]}
+      />
+      <div className="flex items-center space-x-2">
+        <Link href="/salons">
+          <Button variant="outline" size="sm">&larr; Kuaförler</Button>
+        </Link>
+        <Link href="/">
+          <Button variant="outline" size="sm">Ana Sayfa</Button>
+        </Link>
+      </div>
       <div className="space-y-2">
         <h1 className="text-2xl font-bold">{salonQuery.data.name}</h1>
         <p className="text-sm text-muted-foreground">

--- a/src/app/salons/page.tsx
+++ b/src/app/salons/page.tsx
@@ -6,6 +6,7 @@ import { salonsApi } from "@/lib/api";
 import type { Salon } from "@/types";
 import { Card } from "@/components/ui/card";
 import { LoadingPage } from "@/components/ui/loading";
+import { Breadcrumbs } from "@/components/ui/breadcrumbs";
 
 export default function SalonsPage() {
   const { data, isLoading, isError } = useQuery<Salon[]>({
@@ -27,6 +28,12 @@ export default function SalonsPage() {
 
   return (
     <div className="container mx-auto px-4 py-8 space-y-4">
+      <Breadcrumbs
+        items={[
+          { label: "Ana Sayfa", href: "/" },
+          { label: "Kuaförler" },
+        ]}
+      />
       <h1 className="text-2xl font-bold">Kuaförler</h1>
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
         {data.map((salon) => (

--- a/src/components/ui/breadcrumbs.tsx
+++ b/src/components/ui/breadcrumbs.tsx
@@ -1,0 +1,37 @@
+import Link from "next/link";
+import { ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface BreadcrumbItem {
+  label: string;
+  href?: string;
+}
+
+export function Breadcrumbs({
+  items,
+  className,
+}: {
+  items: BreadcrumbItem[];
+  className?: string;
+}) {
+  return (
+    <nav className={cn("text-sm", className)} aria-label="Breadcrumb">
+      <ol className="flex flex-wrap items-center text-muted-foreground">
+        {items.map((item, index) => (
+          <li key={index} className="flex items-center">
+            {item.href ? (
+              <Link href={item.href} className="hover:text-foreground">
+                {item.label}
+              </Link>
+            ) : (
+              <span className="text-foreground">{item.label}</span>
+            )}
+            {index < items.length - 1 && (
+              <ChevronRight className="mx-2 h-4 w-4" />
+            )}
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary
- add breadcrumb UI component
- show breadcrumbs on salon list page
- show breadcrumbs and navigation links on salon detail page

## Testing
- `npm run lint` *(fails: several existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685ef0c7a800832b848d7527b0704f65